### PR TITLE
Fix Validation String Generation

### DIFF
--- a/Classes/Domain/Service/ValidationSettingsService.php
+++ b/Classes/Domain/Service/ValidationSettingsService.php
@@ -71,7 +71,7 @@ class ValidationSettingsService
                 $string .= $this->getSingleValidationString($validation, $configuration);
             }
         }
-        return $string;
+        return rtrim($string, ',');
     }
 
     /**


### PR DESCRIPTION
If method getSingleValidationString returns an empty value, the validation string ends with a comma which it should not! 
This happens for example if ts validation configuration contains "uniqueInPage = 0".
So to fix this just rtrim the validation string before returning it.